### PR TITLE
Support for option hashes

### DIFF
--- a/lib/yard-tomdoc.rb
+++ b/lib/yard-tomdoc.rb
@@ -37,9 +37,9 @@ module YARD
       # TODO: how to figure-out class of argument ?
       tomdoc.arguments.each {|arg| yard.create_tag(:param, "#{arg.name} #{arg.description}") }
 
-      if last_argument = tomdoc.arguments.last
-        last_argument.options.each do |opt|
-          yard.create_tag(:option, "#{last_argument.name} #{opt.description}")
+      tomdoc.arguments.each do |arg|
+        arg.options.each do |opt|
+          yard.create_tag(:option, "#{arg.name} #{opt.name} #{opt.description}")
         end
       end
 

--- a/test/unit/test_docstring.rb
+++ b/test/unit/test_docstring.rb
@@ -19,6 +19,9 @@ describe YARD::Docstring do
 # 
 # text  - The String to be duplicated.
 # count - The Integer number of times to duplicate the text.
+# options - Options (default: {})
+#         :a - Option a
+#         :b - Option b
 # 
 # Examples
 #   multiplex('Tom', 4)
@@ -38,9 +41,21 @@ eof
 
   it "should fill param tags" do
     tags = @docstring.tags(:param)
-    tags.size.assert == 2
+    tags.size.assert == 3
     tags[0].name.assert == 'text'
     tags[1].name.assert == 'count'
+    tags[2].name.assert == 'options'
+  end
+
+  it "should fill options tags" do
+    tags = @docstring.tags(:option)
+    tags.size.assert == 2
+    tags[0].name.assert == 'options'
+    tags[0].pair.name.assert == ':a'
+    tags[0].pair.text.assert == 'Option a'
+    tags[1].name.assert == 'options'
+    tags[1].pair.name.assert == ':b'
+    tags[1].pair.text.assert == 'Option b'
   end
 
   it "should fill examples tags" do


### PR DESCRIPTION
Option hashes were only being evaluated for the last argument, which does not work for functions that take both an options hash and a block.
